### PR TITLE
Add features

### DIFF
--- a/R/p4c_package.R
+++ b/R/p4c_package.R
@@ -274,7 +274,7 @@ plotSingleProf.p4cProfile <- function(p4c_obj, png_fn = NULL, trend_scale = "ada
         write(header_line2, filename1, append = T)
     
         bed_df <- data.frame(chrom = paste0("chr", gsub("chr", "", p4c_obj$bait$chrom)), 
-            start = round(coords), end = round(coords), 
+            start = round(coords), end = round(coords) + 1, 
             value = trend)
     
         write.table(bed_df, filename1, append = T, quote = F, col.names = F, row.names = F, sep="\t")
@@ -470,7 +470,7 @@ plotCompProf.p4cProfile <- function(p4c_obj1, ref_p4c_obj, trend_scale = "adapti
         write(header_line2, filename1, append = T)
     
         bed_df <- data.frame(chrom = paste0("chr", gsub("chr", "", p4c_obj1$bait$chrom)), 
-            start = round(coords), end = round(coords), 
+            start = round(coords), end = round(coords) + 1, 
             value = trend1)
     
         write.table(bed_df, filename1, append = T, quote = F, col.names = F, row.names = F, sep="\t")
@@ -490,7 +490,7 @@ plotCompProf.p4cProfile <- function(p4c_obj1, ref_p4c_obj, trend_scale = "adapti
         write(header_line2, filename2, append = T)
     
         bed_df <- data.frame(chrom = paste0("chr", gsub("chr", "", p4c_obj1$bait$chrom)), 
-            start = round(coords), end = round(coords), 
+            start = round(coords), end = round(coords) + 1, 
             value = ref_trend)
     
         write.table(bed_df, filename2, append = T, quote = F, col.names = F, row.names = F, sep="\t")

--- a/R/p4c_package.R
+++ b/R/p4c_package.R
@@ -145,6 +145,7 @@ summary.p4cProfile <- function(p4c_obj)
 #' @param legend.text Character vector with length 2. Controls the text in the color legend of the trendline.
 #'  The default are the names of the profiles.    
 #' @param col Vector with length 2 that controls the colors of each profile in a comparative plot. 
+#' @param trend_only Optional. Logical that defines whether only the trend plot should be displayed.
 #' 
 #' @examples 
 #' \donttest{
@@ -332,8 +333,13 @@ plotSingleProf.p4cProfile <- function(p4c_obj, png_fn = NULL, trend_scale = "ada
     # plot main trend
     lines(coords, trend, type = "l", lwd = 3, col = "black")
     
-    if (trend_only) 
+    if (trend_only){
+        if (!is.null(png_fn))
+        {
+            dev.off()
+        }
         return()
+    }
     
     # plot dgram
     par(mar = c(4, 4, 0, 2))
@@ -404,9 +410,10 @@ plotCompProf <- function(p4c_obj1, ref_p4c_obj, trend_scale, png_fn, col, min_wi
     xlim, zlim, legend.text, ylim, dgram.method, main, sd) UseMethod("plotCompProf")
 
 #' @export
-plotCompProf.p4cProfile <- function(p4c_obj1, ref_p4c_obj, trend_scale = "adaptive", 
-    png_fn = NULL, col = c("red", "black"), min_win_cov = 50, xlim, zlim = c(-1.5, 
-        1.5), legend.text, ylim, dgram.method = "delta", main, sd = 2, ...)
+plotCompProf.p4cProfile <- function(p4c_obj1, ref_p4c_obj, trend_scale = "adaptive",
+        png_fn = NULL, col = c("red", "black"), 
+        min_win_cov = 50, xlim, zlim = c(-1.5, 1.5), legend.text, ylim, 
+        dgram.method = "delta", main, sd = 2, trend_only = FALSE, ...)
         {
     # normalize p4c_obj1 to p4c_obj2
     p4c_obj1 <- .p4cNormDgram(p4c_obj1, ref_p4c_obj)
@@ -432,7 +439,10 @@ plotCompProf.p4cProfile <- function(p4c_obj1, ref_p4c_obj, trend_scale = "adapti
             res = p4c_obj1$figure_params$png_res)
     }
     
-    layout(matrix(1:3, nrow = 3), heights = c(2.5, 0.2, 2))
+    if(!trend_only)
+    {
+        layout(matrix(1:3, nrow = 3), heights = c(2.5, 0.2, 2))
+    }
     par(cex = 1)
     par(mar = c(0, 4, 0, 2))
     par(oma = c(2, 0.4, 1, 0.4))
@@ -487,6 +497,14 @@ plotCompProf.p4cProfile <- function(p4c_obj1, ref_p4c_obj, trend_scale = "adapti
     
     if (!missing(main)) 
         title(main = main)
+    
+    if (trend_only){
+        if (!is.null(png_fn))
+        {
+            dev.off()
+        }
+        return()
+    }
     
     par(mar = c(0, 4, 0, 2))
     


### PR DESCRIPTION
Hi,
Here are proposed enhancements. If you are interested in only some of them I can do different PR. For the moment, I did not test them except p4cexportBedGraph so if you are interested, I would do some tests before you merge.
1. In `p4cExportBedGraph`, accept numeric values for trend_scale (as in plot) but 0 is also allowed to be raw values. (I also changed the separator to tab and add one to the end coordinates as bedgraph intervals are half-open).
2. `trend_only` was used in `plotSingleProf` but not documented and was not closing the png files. I corrected this and extended it to `plotCompProf`.
3. I added `filename1` and `filename2` in the plot, to output the trend as bedgraph in `plot` (this one has not been tested).

Tell me what you think