### PR TITLE
Set param around_fend

### DIFF
--- a/inst/conf/pipeline.conf
+++ b/inst/conf/pipeline.conf
@@ -30,3 +30,4 @@ TG3C.min_map_qual=30
 #=======fendchain to adj (including filtering switchers)=====
 TG3C.switch_ratio=0.1
 TG3C.filter_near_sonic=1
+TG3C.around_fends=3

--- a/inst/perl/map3c/TG3C/import3C.pl
+++ b/inst/perl/map3c/TG3C/import3C.pl
@@ -266,7 +266,7 @@ if ( $opt->get_opt( "TG3C.split_tracks_by_baits", "TRUE" ) == "TRUE" ) {
       . "-sample_id $sample_id "
       . "-redb_dir $dir_redb "
       . "-re_seq $re "
-      . "-log_file $wd/logs/bait_umis.log"
+      . "-log_file $wd/logs/bait_umis.log "
       . "-around_fends $around_fends";
     my $ret = system($cmd);
     if ($ret) { warn "Couldn't split adj by baits\n"; }

--- a/inst/perl/map3c/TG3C/import3C.pl
+++ b/inst/perl/map3c/TG3C/import3C.pl
@@ -255,7 +255,7 @@ if ( $opt->get_opt( "TG3C.split_tracks_by_baits", "TRUE" ) == "TRUE" ) {
     print STDERR "3CPipe: will split tracks to baits\n";
     my ($dir_redb)     = $opt->get_opt("TG3C.redb");
     my ($re)           = $opt->get_opt("TG3C.RE_seq");
-    my ($around_fends) = $opt->get_opt("TG3C.around_fends");
+    my ($around_fends) = $opt->get_opt("TG3C.around_fends", 3);
     my @conf_files = grep( /^\@/, @ARGV );
     my $conf_file = substr( $conf_files[0], 1 );
     my $cmd =

--- a/inst/perl/map3c/TG3C/import3C.pl
+++ b/inst/perl/map3c/TG3C/import3C.pl
@@ -253,8 +253,9 @@ if ( $opt->get_opt( "TG3C.do_adj_coord", 0 ) ) {
 ############################
 if ( $opt->get_opt( "TG3C.split_tracks_by_baits", "TRUE" ) == "TRUE" ) {
     print STDERR "3CPipe: will split tracks to baits\n";
-    my ($dir_redb) = $opt->get_opt("TG3C.redb");
-    my ($re)       = $opt->get_opt("TG3C.RE_seq");
+    my ($dir_redb)     = $opt->get_opt("TG3C.redb");
+    my ($re)           = $opt->get_opt("TG3C.RE_seq");
+    my ($around_fends) = $opt->get_opt("TG3C.around_fends");
     my @conf_files = grep( /^\@/, @ARGV );
     my $conf_file = substr( $conf_files[0], 1 );
     my $cmd =
@@ -265,7 +266,8 @@ if ( $opt->get_opt( "TG3C.split_tracks_by_baits", "TRUE" ) == "TRUE" ) {
       . "-sample_id $sample_id "
       . "-redb_dir $dir_redb "
       . "-re_seq $re "
-      . "-log_file $wd/logs/bait_umis.log";
+      . "-log_file $wd/logs/bait_umis.log"
+      . "-around_fends $around_fends";
     my $ret = system($cmd);
     if ($ret) { warn "Couldn't split adj by baits\n"; }
 }

--- a/inst/perl/map3c/TG3C/split_mplex_adj.pl
+++ b/inst/perl/map3c/TG3C/split_mplex_adj.pl
@@ -12,10 +12,10 @@ require map3c::TG3C::BaitsTab4C;
 require map3c::TG3C::SamplesTab4C;
 
 if (scalar @ARGV < 4) {
-    die "usage $0 --adj <adj> --samples_tab <tab> --baits_tab <tab> --sample_id <samples_id> --redb_dir <> --re_seq <> --log_file <>\n";
+    die "usage $0 --adj <adj> --samples_tab <tab> --baits_tab <tab> --sample_id <samples_id> --redb_dir <> --re_seq <> --log_file <> --around_fends <>\n";
 }
 
-my ($conf_file, $adj_fn, $sample_id, $redb_dir, $re_seq, $bait_tab_fn, $samp_tab_fn);
+my ($conf_file, $adj_fn, $sample_id, $redb_dir, $re_seq, $bait_tab_fn, $samp_tab_fn, $around_fends);
 my $log_file = undef;
 GetOptions(
            "baits_tab=s" => \$bait_tab_fn,
@@ -24,7 +24,8 @@ GetOptions(
            "sample_id=i" => \$sample_id,
            "redb_dir=s"  => \$redb_dir,
            "log_file=s"  => \$log_file,
-           "re_seq=s"    => \$re_seq
+           "re_seq=s"    => \$re_seq,
+           "around_fends=i" => \$around_fends
            )
 	or die "not all args supplied\n";
 
@@ -89,7 +90,7 @@ sub print_to_bait_fh {
     my $matched = 0;
 
     #step one fend1 before and after to map
-    for (my $cur_f = $fend1-3; $cur_f <= $fend1+3; $cur_f++) {
+    for (my $cur_f = $fend1-$around_fends; $cur_f <= $fend1+$around_fends; $cur_f++) {
 
         if (exists $bait_fends->{$cur_f}) {
             $cur_bait_name = $bait_fends->{$cur_f};


### PR DESCRIPTION
Hi,
When you have viewpoints which are close one to the other you may be interested in having the profile for each of them.
This PR allows to set the parameter `around_fend` which is the number of fend around viewpoint which should be attach to the viewpoint. By default it is 3 which means the fends of the viewpoint's fend -3 to the viewpoint's fend +3 are attached to the viewpoint. You can set it to 0 if you only want the fend corresponding exactly to the viewpoint to be attached to the viewpoint.
If you are interested in this PR, I need to write the corresponding documentation.